### PR TITLE
[AWS] Add AWS EB redirection config

### DIFF
--- a/.ebextensions/alb-http-to-https-redirection.config
+++ b/.ebextensions/alb-http-to-https-redirection.config
@@ -1,0 +1,17 @@
+Resources:
+ AWSEBV2LoadBalancerListener:
+  Type: AWS::ElasticLoadBalancingV2::Listener
+  Properties:
+    LoadBalancerArn:
+      Ref: AWSEBV2LoadBalancer
+    Port: 80
+    Protocol: HTTP
+    DefaultActions:
+      - Type: redirect
+        RedirectConfig:
+          Host: "#{host}"
+          Path: "/#{path}"
+          Port: "443"
+          Protocol: "HTTPS"
+          Query: "#{query}"
+          StatusCode: "HTTP_301"


### PR DESCRIPTION
## Description

Add HTTP to HTTPS redirection config:

```
Resources:
 AWSEBV2LoadBalancerListener:
  Type: AWS::ElasticLoadBalancingV2::Listener
  Properties:
    LoadBalancerArn:
      Ref: AWSEBV2LoadBalancer
    Port: 80
    Protocol: HTTP
    DefaultActions:
      - Type: redirect
        RedirectConfig:
          Host: "#{host}"
          Path: "/#{path}"
          Port: "443"
          Protocol: "HTTPS"
          Query: "#{query}"
          StatusCode: "HTTP_301"
```
