### PR TITLE
[AWS] Migrate to AWS Linux 2

### DIFF
--- a/.ebextensions/nodecommand.config
+++ b/.ebextensions/nodecommand.config
@@ -1,3 +1,0 @@
-option_settings:
-  aws:elasticbeanstalk:container:nodejs:
-    NodeCommand: "npm run server-start"

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: node index.js


### PR DESCRIPTION
## Description

Use the new `Procfile`, and remove the old `.ebextensions/nodecommand.config`.